### PR TITLE
Fix message display for verify command

### DIFF
--- a/base/hourai/bot/extensions/validation/context.py
+++ b/base/hourai/bot/extensions/validation/context.py
@@ -119,8 +119,12 @@ class ValidationContext:
         if self.approved:
             message.append(f"Verified user: {member.mention} ({member.id}).")
         else:
-            message.append(f"{ping_target}. User {member.mention} "
-                           f"({member.id}) requires manual verification.")
+            if ping_target != '':
+                message.append(f"{ping_target}. User {member.mention} "
+                               f"({member.id}) requires manual verification.")
+            else:
+                message.append(f"User {member.mention} "
+                               f"({member.id}) requires manual verification.")
 
         if include_invite:
             invite, vanity = await self.get_join_invite()


### PR DESCRIPTION
Fixed issue with Hourai displaying a period at the start of the message when the ~validation verify command was run manually for a user already present on the server.

<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
