### PR TITLE
Make python side of Hourai recognize admins as mods

### DIFF
--- a/base/hourai/utils/__init__.py
+++ b/base/hourai/utils/__init__.py
@@ -12,7 +12,7 @@ from hourai import config
 from datetime import timedelta
 
 
-MODERATOR_PREFIX = 'mod'
+MODERATOR_PREFIX = ('mod', 'admin')
 DELETED_USER_REGEX = re.compile(r'Deleted User [0-9a-fA-F]{8}')
 
 


### PR DESCRIPTION
The rust side of Hourai recognizes anyone with a role that begins with "mod" or "admin" to be a moderator. The python side was never updated to recognize the "admin" prefix. This PR fixes this.

<!-- Please use English language -->
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes. Potentially?
- [ ] No

If yes, please describe the impact and migration path for existing applications:

If people are relying on the broken behavior where the python half of the bot doesn't recognize admins as moderators, then it's a breaking change. I don't think that's commonplace, or a good idea though.